### PR TITLE
Use index page for QR code v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# faGe Quiz
+
+Simple quiz game with training and battle modes.
+
+## Setup
+No build step is required. Serve the files with any static server or open `index.html` directly.
+
+Run placeholder tests with:
+```bash
+npm test
+```

--- a/battle.html
+++ b/battle.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container battle-container">
     <h1>Battle-Modus</h1>
-    <img id="qr" src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=faGe-Quiz-Battle" alt="QR-Code" />
+    <img id="qr" alt="QR-Code" />
     <div class="player-count">
       <label for="players">Anzahl Mitspieler:</label>
       <input type="number" id="players" min="1" value="2">

--- a/battle.js
+++ b/battle.js
@@ -1,14 +1,40 @@
 import { questions } from './questions.js';
-import { games } from './games.js';
+import { getGames, saveGames } from './games.js';
 
-const container = document.getElementById('battle');
-const battleBtn = document.getElementById('battle-btn');
+const container = document.querySelector('.battle-container');
+const qrImg = document.getElementById('qr');
+const startBtn = document.getElementById('startBtn');
+
+function getJoinUrl(token) {
+  const url = new URL('index.html', location.href);
+  url.searchParams.set('token', token);
+  return url.href;
+}
+
+const params = new URLSearchParams(window.location.search);
+const tokenParam = params.get('token');
+let games = getGames();
+
+if (tokenParam) {
+  startBtn.style.display = 'none';
+  const game = games.find(g => g.token === tokenParam);
+  if (game) {
+    const joinUrl = getJoinUrl(tokenParam);
+    qrImg.src = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(joinUrl)}`;
+    renderGame(game);
+  } else {
+    container.innerHTML = '<p>Spiel nicht gefunden.</p>';
+  }
+} else {
+  startBtn.addEventListener('click', createGame);
+}
 
 function shuffle(arr) {
   return arr.sort(() => Math.random() - 0.5);
 }
 
 function createGame() {
+  games = getGames();
   const id = games.length + 1;
   const token = Math.random().toString(36).substring(2, 10);
   const frageIds = shuffle([...questions])
@@ -19,17 +45,18 @@ function createGame() {
   const game = {
     id,
     token,
-    anzahlSpiele: 0,
+    playerCount: 1,
     fragen: frageIds,
     datestamp
   };
 
   games.push(game);
+  saveGames(games);
+  const joinUrl = getJoinUrl(token);
+  qrImg.src = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(joinUrl)}`;
   renderGame(game);
 }
 
 function renderGame(game) {
   container.innerHTML = `<pre>${JSON.stringify(game, null, 2)}</pre>`;
 }
-
-battleBtn.addEventListener('click', createGame);

--- a/games.js
+++ b/games.js
@@ -1,1 +1,9 @@
-export const games = [];
+const STORAGE_KEY = 'faGeGames';
+
+export function getGames() {
+  return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+}
+
+export function saveGames(games) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(games));
+}

--- a/index.html
+++ b/index.html
@@ -21,5 +21,6 @@
       </a>
     </div>
   </div>
+  <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,17 @@
+import { getGames, saveGames } from './games.js';
+
+function handleToken() {
+  const params = new URLSearchParams(window.location.search);
+  const token = params.get('token');
+  if (token) {
+    const games = getGames();
+    const game = games.find(g => g.token === token);
+    if (game) {
+      game.playerCount = (game.playerCount || 0) + 1;
+      saveGames(games);
+    }
+    window.location.href = `battle.html?token=${token}`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', handleToken);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fage-quiz",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}


### PR DESCRIPTION
## Summary
- persist game state in `localStorage`
- update index page token handler to increment `playerCount`
- save new games so QR links work across tabs

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6872c318c758832f8fdc6d71eb099674