### PR TITLE
Add Jest and tests for games storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Simple quiz game with training and battle modes.
 ## Setup
 No build step is required. Serve the files with any static server or open `index.html` directly.
 
-Run placeholder tests with:
+Run the Jest test suite with:
 ```bash
+npm install
 npm test
 ```

--- a/__tests__/games.test.js
+++ b/__tests__/games.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+
+// Helper to setup localStorage mock
+function mockLocalStorage() {
+  const store = {};
+  return {
+    getItem: jest.fn(key => (key in store ? store[key] : null)),
+    setItem: jest.fn((key, value) => { store[key] = value; }),
+    removeItem: jest.fn(key => { delete store[key]; }),
+    clear: jest.fn(() => { Object.keys(store).forEach(k => delete store[k]); })
+  };
+}
+
+describe('games storage', () => {
+  beforeEach(() => {
+    global.localStorage = mockLocalStorage();
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('saveGames stores JSON in localStorage', async () => {
+    const { saveGames } = await import('../games.js');
+    const data = [{ id: 1 }];
+    saveGames(data);
+    expect(global.localStorage.setItem).toHaveBeenCalledWith('games', JSON.stringify(data));
+  });
+
+  test('getGames returns parsed games', async () => {
+    const data = [{ id: 2 }];
+    global.localStorage.getItem = jest.fn(() => JSON.stringify(data));
+    const { getGames } = await import('../games.js');
+    expect(getGames()).toEqual(data);
+  });
+
+  test('getGames returns empty array when nothing stored', async () => {
+    global.localStorage.getItem = jest.fn(() => null);
+    const { getGames } = await import('../games.js');
+    expect(getGames()).toEqual([]);
+  });
+});

--- a/games.js
+++ b/games.js
@@ -1,1 +1,17 @@
-export const games = [];
+const STORAGE_KEY = 'games';
+
+export function getGames() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+export function saveGames(arr) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(arr));
+}
+
+export const games = getGames();

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- use localStorage utilities in games.js
- add jest dev dependency and test script
- test getGames and saveGames with jest
- document how to run tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873472a3d40832f83eb28a2afd8435f