### PR TITLE
Update join URLs to use spiele-Token

### DIFF
--- a/battle.js
+++ b/battle.js
@@ -13,12 +13,12 @@ if (siteQrContainer) {
 
 function getJoinUrl(token) {
   const url = new URL('index.html', location.href);
-  url.searchParams.set('token', token);
+  url.searchParams.set('spiele-Token', token);
   return url.href;
 }
 
 const params = new URLSearchParams(window.location.search);
-const tokenParam = params.get('token');
+const tokenParam = params.get('spiele-Token');
 
 let games = getGames();
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import { getGames, saveGames } from './games.js';
 
 function handleToken() {
   const params = new URLSearchParams(window.location.search);
-  const token = params.get('token');
+  const token = params.get('spiele-Token');
   if (token) {
     const games = getGames();
     const game = games.find(g => g.token === token);
@@ -12,7 +12,7 @@ function handleToken() {
       saveGames(games);
 
     }
-    window.location.href = `battle.html?token=${token}`;
+    window.location.href = `battle.html?spiele-Token=${token}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- update query parameter from `token` to `spiele-Token`
- update redirect logic accordingly

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ad705e9c832f8a22c45d4bd9cd55