### PR TITLE
Update QR code link logic

### DIFF
--- a/battle.js
+++ b/battle.js
@@ -6,9 +6,16 @@ const qrContainer = document.getElementById('qr');
 const siteQrContainer = document.getElementById('siteQr');
 const startBtn = document.getElementById('startBtn');
 
-// Display a QR code for the main website
-if (siteQrContainer) {
-  new QRCode(siteQrContainer, 'https://www.mei-deo.ch');
+function updateQr(container, url) {
+  if (!container) return;
+  container.innerHTML = '';
+  new QRCode(container, url);
+}
+
+function getIndexUrl(token) {
+  const url = new URL('index.html', location.href);
+  if (token) url.searchParams.set('spiele-Token', token);
+  return url.href;
 }
 
 function getJoinUrl(token) {
@@ -20,6 +27,8 @@ function getJoinUrl(token) {
 const params = new URLSearchParams(window.location.search);
 const tokenParam = params.get('spiele-Token');
 
+updateQr(siteQrContainer, getIndexUrl(tokenParam));
+
 let games = getGames();
 
 
@@ -28,10 +37,8 @@ if (tokenParam) {
   const game = games.find(g => g.token === tokenParam);
   if (game) {
     const joinUrl = getJoinUrl(tokenParam);
-    if (qrContainer) {
-      qrContainer.innerHTML = '';
-      new QRCode(qrContainer, joinUrl);
-    }
+    updateQr(qrContainer, joinUrl);
+    updateQr(siteQrContainer, joinUrl);
     renderGame(game);
   } else {
     container.innerHTML = '<p>Spiel nicht gefunden.</p>';
@@ -75,10 +82,8 @@ function createGame() {
   saveGames(games);
 
   const joinUrl = getJoinUrl(token);
-  if (qrContainer) {
-    qrContainer.innerHTML = '';
-    new QRCode(qrContainer, joinUrl);
-  }
+  updateQr(qrContainer, joinUrl);
+  updateQr(siteQrContainer, joinUrl);
   renderGame(game);
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 
 import { getGames, saveGames } from './games.js';
 
+const CURRENT_TOKEN_KEY = 'currentGameToken';
+
 function handleToken() {
   const params = new URLSearchParams(window.location.search);
   const token = params.get('spiele-Token');
@@ -10,8 +12,8 @@ function handleToken() {
     if (game) {
       game.playerCount = (game.playerCount || 0) + 1;
       saveGames(games);
-
     }
+    localStorage.setItem(CURRENT_TOKEN_KEY, token);
     window.location.href = `battle.html?spiele-Token=${token}`;
   }
 }


### PR DESCRIPTION
## Summary
- show QR codes for the index page with optional game token
- update QR code when game is loaded or created
- remember joined game token in localStorage

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6873c7c38c78832f870e20bb5cdd3f29