### PR TITLE
Append tokenid param for QR URLs

### DIFF
--- a/battle.js
+++ b/battle.js
@@ -14,18 +14,18 @@ function updateQr(container, url) {
 
 function getIndexUrl(token) {
   const url = new URL('index.html', location.href);
-  if (token) url.searchParams.set('spiele-Token', token);
+  if (token) url.searchParams.set('tokenid', token);
   return url.href;
 }
 
 function getJoinUrl(token) {
   const url = new URL('index.html', location.href);
-  url.searchParams.set('spiele-Token', token);
+  url.searchParams.set('tokenid', token);
   return url.href;
 }
 
 const params = new URLSearchParams(window.location.search);
-const tokenParam = params.get('spiele-Token');
+const tokenParam = params.get('tokenid');
 
 updateQr(siteQrContainer, getIndexUrl(tokenParam));
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const CURRENT_TOKEN_KEY = 'currentGameToken';
 
 function handleToken() {
   const params = new URLSearchParams(window.location.search);
-  const token = params.get('spiele-Token');
+  const token = params.get('tokenid');
   if (token) {
     const games = getGames();
     const game = games.find(g => g.token === token);
@@ -14,7 +14,7 @@ function handleToken() {
       saveGames(games);
     }
     localStorage.setItem(CURRENT_TOKEN_KEY, token);
-    window.location.href = `battle.html?spiele-Token=${token}`;
+    window.location.href = `battle.html?tokenid=${token}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- update URL parameter handling for battle and join pages
- QR codes now include `tokenid` in their links

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873cef8f68c832fae279a87208d6d70