### PR TITLE
Update titles and show game info

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -3,15 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Battle v5</title>
+  <title>Battle v7</title>
   <link rel="stylesheet" href="style.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 </head>
 <body>
   <div class="container battle-container">
-    <h1>Battle-Modus v5</h1>
+    <h1>Battle-Modus v7</h1>
     <div id="siteQr" alt="mei-deo QR-Code"></div>
     <div id="qr" alt="QR-Code"></div>
+    <div id="gameDetails" class="game-info"></div>
     <div class="player-count">
       <label for="players">Anzahl Mitspieler:</label>
       <input type="number" id="players" min="1" value="2">

--- a/battle.js
+++ b/battle.js
@@ -5,6 +5,7 @@ const container = document.querySelector('.battle-container');
 const qrContainer = document.getElementById('qr');
 const siteQrContainer = document.getElementById('siteQr');
 const startBtn = document.getElementById('startBtn');
+const gameDetailsEl = document.getElementById('gameDetails');
 
 function updateQr(container, url) {
   if (!container) return;
@@ -90,11 +91,9 @@ function createGame() {
 }
 
 function renderGame(game) {
-  let pre = document.getElementById('gameInfo');
-  if (!pre) {
-    pre = document.createElement('pre');
-    pre.id = 'gameInfo';
-    container.appendChild(pre);
+  if (gameDetailsEl) {
+    gameDetailsEl.innerHTML = `
+      <p>Spielnr.: ${game.id}</p>
+      <p>Spieleranzahl: ${game.playerCount}</p>`;
   }
-  pre.textContent = JSON.stringify(game, null, 2);
 }

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>fagequiz! v5</title>
+  <title>fagequiz! v7</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
   <div class="container">
-    <h1>fagequiz! v5</h1>
+    <h1>fagequiz! v7</h1>
     <div class="tiles">
       <a href="training.html" class="tile">
         <i class="fas fa-dumbbell"></i>

--- a/style.css
+++ b/style.css
@@ -156,3 +156,8 @@ body {
   color: #00695c;
   font-size: 0.9rem;
 }
+
+.game-info {
+  font-size: 1.1rem;
+  color: #004d40;
+}

--- a/training.html
+++ b/training.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Training v5</title>
+  <title>Training v7</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <div class="container">
-    <h1>Training v5</h1>
+    <h1>Training v7</h1>
     <div id="quiz" class="quiz-card"></div>
     <a href="index.html" class="back-btn">Abbrechen</a>
   </div>


### PR DESCRIPTION
## Summary
- bump version in all page titles to v7
- add container for game details on the battle screen
- render game id and player count below the QR code

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874f4b7d6fc832f8c32566ae50b84f9