### PR TITLE
Add simple battle mode

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -22,6 +22,8 @@
       <input type="number" id="players" min="1" value="2">
     </div>
     <button class="start-btn" id="startBtn">Start</button>
+    <div id="status" class="status"></div>
+    <div id="quiz" class="quiz-card"></div>
     <a href="index.html" class="back-btn">Zurück</a>
 
   </div>

--- a/battle.js
+++ b/battle.js
@@ -1,65 +1,54 @@
 import { questions } from './questions.js';
 import { getGames, saveGames } from './games.js';
 
+const CURRENT_TOKEN_KEY = 'currentGameToken';
+const CURRENT_PLAYER_KEY = 'currentPlayerId';
+const COUNTDOWN_SECONDS = 5;
+
 const container = document.querySelector('.battle-container');
 const qrContainer = document.getElementById('qr');
 const siteQrContainer = document.getElementById('siteQr');
 const startBtn = document.getElementById('startBtn');
 const gameDetailsEl = document.getElementById('gameDetails');
 const devInfoEl = document.getElementById('devInfo');
+const quizEl = document.getElementById('quiz');
+const statusEl = document.getElementById('status');
 
-
-function updateQr(container, url) {
-  if (!container) return;
-  container.innerHTML = '';
-  new QRCode(container, url);
+function updateQr(el, url) {
+  if (!el) return;
+  el.innerHTML = '';
+  new QRCode(el, url);
 }
 
 function getIndexUrl(token) {
   const url = new URL('index.html', location.href);
   url.searchParams.set('tokenid', token || 'unbekannt');
-
   return url.href;
 }
 
 function getJoinUrl(token) {
   const url = new URL('index.html', location.href);
   url.searchParams.set('tokenid', token || 'unbekannt');
-
   return url.href;
 }
 
+let games = getGames();
 const params = new URLSearchParams(window.location.search);
-const tokenParam = params.get('tokenid');
+let tokenParam = params.get('tokenid');
+let game = tokenParam ? games.find(g => g.token === tokenParam) : null;
+let playerId = parseInt(localStorage.getItem(CURRENT_PLAYER_KEY), 10);
+let quizStarted = false;
+let selected = [];
+let current = 0;
+let score = 0;
 
 updateQr(siteQrContainer, getIndexUrl(tokenParam));
-
-let games = getGames();
-
 renderDevInfo(null);
 
-
-if (tokenParam) {
-  startBtn.style.display = 'none';
-  const game = games.find(g => g.token === tokenParam);
-  if (game) {
-    const joinUrl = getJoinUrl(tokenParam);
-    updateQr(qrContainer, joinUrl);
-    updateQr(siteQrContainer, getIndexUrl(tokenParam));
-    renderGame(game);
-  } else {
-    container.innerHTML = '<p>Spiel nicht gefunden.</p>';
-
-    startBtn.style.display = 'inline-block';
-    container.appendChild(startBtn);
-    startBtn.addEventListener('click', createGame);
-    const backLink = document.createElement('a');
-    backLink.href = 'index.html';
-    backLink.textContent = 'Zurück';
-    backLink.className = 'back-btn';
-    container.appendChild(backLink);
-
-  }
+if (tokenParam && game) {
+  joinGame();
+  renderGame();
+  startPolling();
 } else {
   startBtn.addEventListener('click', createGame);
 }
@@ -77,38 +66,172 @@ function createGame() {
     .map(q => q.id);
   const datestamp = new Date().toISOString();
 
-  const game = {
+  const gameObj = {
     id,
     token,
     playerCount: 1,
+    players: [{ id: 1, score: null, finished: false }],
     fragen: frageIds,
-    datestamp
+    datestamp,
+    startTime: null
   };
 
-  games.push(game);
+  games.push(gameObj);
   saveGames(games);
-
-  const joinUrl = getJoinUrl(token);
-  updateQr(qrContainer, joinUrl);
-  updateQr(siteQrContainer, getIndexUrl(token));
-  renderGame(game);
+  localStorage.setItem(CURRENT_TOKEN_KEY, token);
+  localStorage.setItem(CURRENT_PLAYER_KEY, 1);
+  window.location.href = `battle.html?tokenid=${token}`;
 }
 
-function renderGame(game) {
+function joinGame() {
+  if (!game) return;
+  if (!game.players) game.players = [];
+  if (!playerId || !game.players.some(p => p.id === playerId)) {
+    playerId = game.players.length + 1;
+    game.players.push({ id: playerId, score: null, finished: false });
+    game.playerCount = game.players.length;
+    saveGames(games);
+    localStorage.setItem(CURRENT_PLAYER_KEY, playerId);
+  }
+  localStorage.setItem(CURRENT_TOKEN_KEY, game.token);
+}
+
+function renderGame() {
+  if (!game) return;
+  updateQr(qrContainer, getJoinUrl(game.token));
+  updateQr(siteQrContainer, getIndexUrl(game.token));
   if (gameDetailsEl) {
     gameDetailsEl.innerHTML = `
       <p>Spielnr.: ${game.id}</p>
-      <p>Spieleranzahl: ${game.playerCount}</p>`;
+      <p>Spieleranzahl: ${game.playerCount}</p>
+      <p>Du bist Spieler ${playerId}</p>`;
+  }
+  if (playerId === 1 && !game.startTime) {
+    startBtn.style.display = 'inline-block';
+    startBtn.onclick = beginGame;
+  } else {
+    startBtn.style.display = 'none';
   }
   renderDevInfo(game);
 }
 
-function renderDevInfo(game) {
-  if (!devInfoEl) return;
-  try {
-    devInfoEl.textContent = JSON.stringify({ game, games }, null, 2);
-  } catch (err) {
-    devInfoEl.textContent = err.toString();
+function beginGame() {
+  if (!game) return;
+  game.startTime = Date.now() + COUNTDOWN_SECONDS * 1000;
+  saveGames(games);
+  renderGame();
+}
 
+function startPolling() {
+  setInterval(() => {
+    games = getGames();
+    game = games.find(g => g.token === tokenParam);
+    if (!game) return;
+    renderGame();
+    if (game.startTime && !quizStarted) {
+      const diff = Math.ceil((game.startTime - Date.now()) / 1000);
+      if (diff > 0) {
+        statusEl.textContent = `Start in ${diff}...`;
+      } else {
+        statusEl.textContent = '';
+        startQuiz();
+      }
+    }
+    if (quizStarted) {
+      checkResults();
+    }
+  }, 1000);
+}
+
+function startQuiz() {
+  quizStarted = true;
+  selected = game.fragen.map(id => questions.find(q => q.id === id));
+  current = 0;
+  score = 0;
+  showQuestion();
+}
+
+function showQuestion() {
+  const q = selected[current];
+  quizEl.innerHTML = '';
+  const questionEl = document.createElement('div');
+  questionEl.innerHTML = `<p>${current + 1}/5: ${q.frage}</p>`;
+  const answersEl = document.createElement('div');
+  answersEl.className = 'answers';
+  q.antworten.forEach((a, idx) => {
+    const btn = document.createElement('button');
+    btn.textContent = a;
+    btn.addEventListener('click', () => handleAnswer(idx));
+    answersEl.appendChild(btn);
+  });
+  questionEl.appendChild(answersEl);
+  quizEl.appendChild(questionEl);
+}
+
+function handleAnswer(idx) {
+  const q = selected[current];
+  if (idx === q.korrekt) score++;
+  current++;
+  if (current < selected.length) {
+    showQuestion();
+  } else {
+    finishQuiz();
   }
 }
+
+function finishQuiz() {
+  const gamesArr = getGames();
+  const g = gamesArr.find(gm => gm.token === tokenParam);
+  if (g) {
+    const p = g.players.find(pl => pl.id === playerId);
+    if (p) {
+      p.score = score;
+      p.finished = true;
+      saveGames(gamesArr);
+    }
+  }
+  statusEl.textContent = `Warte auf andere Spieler... Dein Ergebnis: ${score}/5`;
+  quizEl.innerHTML = '';
+}
+
+function checkResults() {
+  if (!game.players) return;
+  const finished = game.players.filter(p => p.finished).length;
+  if (finished === game.playerCount && game.players.every(p => p.score !== null)) {
+    showScoreboard();
+  } else {
+    statusEl.textContent = `Warte auf andere Spieler... (${finished}/${game.playerCount})`;
+  }
+}
+
+function showScoreboard() {
+  quizEl.innerHTML = '';
+  const list = document.createElement('ul');
+  list.className = 'scoreboard';
+  let best = 0;
+  game.players.forEach(p => { if (p.score > best) best = p.score; });
+  game.players.forEach(p => {
+    const li = document.createElement('li');
+    li.textContent = `Spieler ${p.id}: ${p.score} Punkte`;
+    if (p.score === best) li.style.fontWeight = 'bold';
+    list.appendChild(li);
+  });
+  quizEl.appendChild(list);
+  const winners = game.players.filter(p => p.score === best).map(p => `Spieler ${p.id}`).join(', ');
+  statusEl.textContent = `Gewonnen hat: ${winners}`;
+  const backLink = document.createElement('a');
+  backLink.href = 'index.html';
+  backLink.textContent = 'Zurück';
+  backLink.className = 'back-btn';
+  quizEl.appendChild(backLink);
+}
+
+function renderDevInfo(g) {
+  if (!devInfoEl) return;
+  try {
+    devInfoEl.textContent = JSON.stringify({ game: g, games }, null, 2);
+  } catch (err) {
+    devInfoEl.textContent = err.toString();
+  }
+}
+

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 import { getGames, saveGames } from './games.js';
 
 const CURRENT_TOKEN_KEY = 'currentGameToken';
+const CURRENT_PLAYER_KEY = 'currentPlayerId';
 
 function handleToken() {
   const params = new URLSearchParams(window.location.search);
@@ -10,8 +11,12 @@ function handleToken() {
     const games = getGames();
     const game = games.find(g => g.token === token);
     if (game) {
-      game.playerCount = (game.playerCount || 0) + 1;
+      game.players = game.players || [];
+      const playerId = game.players.length + 1;
+      game.players.push({ id: playerId, score: null, finished: false });
+      game.playerCount = game.players.length;
       saveGames(games);
+      localStorage.setItem(CURRENT_PLAYER_KEY, playerId);
     }
     localStorage.setItem(CURRENT_TOKEN_KEY, token);
     window.location.href = `battle.html?tokenid=${token}`;

--- a/style.css
+++ b/style.css
@@ -174,3 +174,19 @@ body {
   text-align: left;
 }
 
+.status {
+  font-size: 1.5rem;
+  margin-top: 20px;
+}
+
+.scoreboard {
+  list-style: none;
+  margin-top: 20px;
+  padding: 0;
+  font-size: 1.2rem;
+}
+
+.scoreboard li {
+  margin-bottom: 5px;
+}
+


### PR DESCRIPTION
## Summary
- add status and quiz areas to `battle.html`
- store player info when joining via `index.js`
- implement local multiplayer logic in `battle.js`
- add styles for battle status and scoreboard

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68750656a184832fb8920f1bf6909fee