### PR TITLE
Add admin interface and reporting system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+
+function mockLocalStorage() {
+  const store = {};
+  return {
+    getItem: jest.fn(key => (key in store ? store[key] : null)),
+    setItem: jest.fn((key, value) => { store[key] = value; }),
+    removeItem: jest.fn(key => { delete store[key]; }),
+    clear: jest.fn(() => { Object.keys(store).forEach(k => delete store[k]); })
+  };
+}
+
+describe('storage helpers', () => {
+  beforeEach(() => {
+    global.localStorage = mockLocalStorage();
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('addReport stores report', async () => {
+    const { addReport, getReports } = await import('../storage.js');
+    addReport({ question: { id: 1 }, message: 'Test' });
+    expect(getReports()).toEqual([{ question: { id: 1 }, message: 'Test' }]);
+  });
+
+  test('removeReport deletes report', async () => {
+    const { addReport, removeReport, getReports } = await import('../storage.js');
+    addReport({ question: { id: 1 }, message: 'Test' });
+    removeReport(0);
+    expect(getReports()).toEqual([]);
+  });
+
+  test('addCustomQuestion overrides', async () => {
+    const { addCustomQuestion, getCustomQuestions } = await import('../storage.js');
+    addCustomQuestion({ id: 1, frage: 'a' });
+    addCustomQuestion({ id: 1, frage: 'b' });
+    expect(getCustomQuestions()).toEqual([{ id: 1, frage: 'b' }]);
+  });
+});

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+</head>
+<body>
+  <div class="container" id="adminContainer">
+    <h1>Adminbereich</h1>
+    <div id="reports"></div>
+    <h2>Frage hinzufügen / bearbeiten</h2>
+    <form id="questionForm">
+      <input type="text" id="frage" placeholder="Frage" required />
+      <input type="text" id="a1" placeholder="Antwort 1" required />
+      <input type="text" id="a2" placeholder="Antwort 2" required />
+      <input type="text" id="a3" placeholder="Antwort 3" required />
+      <input type="text" id="a4" placeholder="Antwort 4" required />
+      <input type="number" id="korrekt" min="0" max="3" placeholder="Index der richtigen Antwort" required />
+      <input type="text" id="begruendung" placeholder="Begründung" required />
+      <button type="submit">Speichern</button>
+    </form>
+    <a href="index.html" class="back-btn">Zurück</a>
+  </div>
+  <script type="module" src="admin.js"></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,78 @@
+import { getReports, removeReport, addCustomQuestion } from './storage.js';
+
+const pw = prompt('Passwort:');
+if (pw !== '123') {
+  alert('Falsches Passwort');
+  window.location.href = 'index.html';
+}
+
+const reportsContainer = document.getElementById('reports');
+const form = document.getElementById('questionForm');
+const frage = document.getElementById('frage');
+const a1 = document.getElementById('a1');
+const a2 = document.getElementById('a2');
+const a3 = document.getElementById('a3');
+const a4 = document.getElementById('a4');
+const korrekt = document.getElementById('korrekt');
+const begruendung = document.getElementById('begruendung');
+let editId = null;
+let editReportIndex = null;
+
+function renderReports() {
+  const reports = getReports();
+  reportsContainer.innerHTML = '<h2>Gemeldete Fragen</h2>';
+  if (!reports.length) {
+    reportsContainer.innerHTML += '<p>Keine Meldungen vorhanden.</p>';
+    return;
+  }
+  const list = document.createElement('ul');
+  reports.forEach((r, idx) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${r.question.frage}</strong><br>${r.message}`;
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Bearbeiten';
+    editBtn.addEventListener('click', () => {
+      editId = r.question.id;
+      editReportIndex = idx;
+      frage.value = r.question.frage;
+      a1.value = r.question.antworten[0] || '';
+      a2.value = r.question.antworten[1] || '';
+      a3.value = r.question.antworten[2] || '';
+      a4.value = r.question.antworten[3] || '';
+      korrekt.value = r.question.korrekt;
+      begruendung.value = r.question.begruendung || '';
+    });
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'Löschen';
+    delBtn.addEventListener('click', () => {
+      removeReport(idx);
+      renderReports();
+    });
+    li.appendChild(editBtn);
+    li.appendChild(delBtn);
+    list.appendChild(li);
+  });
+  reportsContainer.appendChild(list);
+}
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  const q = {
+    id: editId || Date.now(),
+    frage: frage.value,
+    antworten: [a1.value, a2.value, a3.value, a4.value],
+    korrekt: parseInt(korrekt.value, 10),
+    begruendung: begruendung.value
+  };
+  addCustomQuestion(q);
+  if (editReportIndex !== null) {
+    removeReport(editReportIndex);
+  }
+  form.reset();
+  editId = null;
+  editReportIndex = null;
+  renderReports();
+  alert('Gespeichert');
+});
+
+renderReports();

--- a/battle.js
+++ b/battle.js
@@ -1,5 +1,15 @@
 import { questions } from './questions.js';
 import { getGames, saveGames } from './games.js';
+import { getCustomQuestions, addReport } from './storage.js';
+function allQuestions() {
+  const base = [...questions];
+  const extras = getCustomQuestions();
+  extras.forEach(q => {
+    const idx = base.findIndex(b => b.id === q.id);
+    if (idx >= 0) base[idx] = q; else base.push(q);
+  });
+  return base;
+}
 
 const CURRENT_TOKEN_KEY = 'currentGameToken';
 const CURRENT_PLAYER_KEY = 'currentPlayerId';
@@ -61,7 +71,7 @@ function createGame() {
   games = getGames();
   const id = games.length + 1;
   const token = Math.random().toString(36).substring(2, 10);
-  const frageIds = shuffle([...questions])
+  const frageIds = shuffle(allQuestions())
     .slice(0, 5)
     .map(q => q.id);
   const datestamp = new Date().toISOString();
@@ -145,7 +155,7 @@ function startPolling() {
 
 function startQuiz() {
   quizStarted = true;
-  selected = game.fragen.map(id => questions.find(q => q.id === id));
+  selected = game.fragen.map(id => allQuestions().find(q => q.id === id));
   current = 0;
   score = 0;
   showQuestion();
@@ -165,6 +175,13 @@ function showQuestion() {
     answersEl.appendChild(btn);
   });
   questionEl.appendChild(answersEl);
+  const reportBtn = document.createElement("button");
+  reportBtn.textContent = "Problem melden";
+  reportBtn.addEventListener("click", () => {
+    const msg = prompt("Was ist das Problem?");
+    if (msg) { addReport({ question: q, message: msg }); alert("Danke für deine Meldung!"); }
+  });
+  questionEl.appendChild(reportBtn);
   quizEl.appendChild(questionEl);
 }
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
         <i class="fas fa-bolt"></i>
         <span>Battle</span>
       </a>
+          <a href="admin.html" class="tile">
+        <i class="fas fa-user-shield"></i>
+        <span>Admin</span>
+      </a>
     </div>
   </div>
   <script type="module" src="index.js"></script>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
 
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
     "jest": "^29.6.2"

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,49 @@
+const REPORTS_KEY = 'reports';
+const CUSTOM_KEY = 'customQuestions';
+
+export function getReports() {
+  const raw = localStorage.getItem(REPORTS_KEY);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+export function saveReports(arr) {
+  localStorage.setItem(REPORTS_KEY, JSON.stringify(arr));
+}
+
+export function addReport(report) {
+  const reports = getReports();
+  reports.push(report);
+  saveReports(reports);
+}
+
+export function removeReport(index) {
+  const reports = getReports();
+  reports.splice(index, 1);
+  saveReports(reports);
+}
+
+export function getCustomQuestions() {
+  const raw = localStorage.getItem(CUSTOM_KEY);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+export function saveCustomQuestions(arr) {
+  localStorage.setItem(CUSTOM_KEY, JSON.stringify(arr));
+}
+
+export function addCustomQuestion(q) {
+  const arr = getCustomQuestions();
+  const idx = arr.findIndex(item => item.id === q.id);
+  if (idx >= 0) arr[idx] = q; else arr.push(q);
+  saveCustomQuestions(arr);
+}

--- a/training.js
+++ b/training.js
@@ -1,4 +1,5 @@
 import { questions } from './questions.js';
+import { getCustomQuestions, addReport } from './storage.js';
 
 const quizContainer = document.getElementById('quiz');
 
@@ -12,7 +13,13 @@ function shuffle(arr) {
 }
 
 function startQuiz() {
-  selected = shuffle([...questions]).slice(0, 5);
+  const base = [...questions];
+  const extras = getCustomQuestions();
+  extras.forEach(q => {
+    const idx = base.findIndex(b => b.id === q.id);
+    if (idx >= 0) base[idx] = q; else base.push(q);
+  });
+  selected = shuffle(base).slice(0, 5);
   current = 0;
   score = 0;
   results = [];
@@ -37,6 +44,16 @@ function showQuestion() {
   });
 
   questionEl.appendChild(answersEl);
+  const reportBtn = document.createElement("button");
+  reportBtn.textContent = "Problem melden";
+  reportBtn.addEventListener("click", () => {
+    const msg = prompt("Was ist das Problem?");
+    if (msg) {
+      addReport({ question: q, message: msg });
+      alert("Danke für deine Meldung!");
+    }
+  });
+  questionEl.appendChild(reportBtn);
   quizContainer.appendChild(questionEl);
 }
 


### PR DESCRIPTION
## Summary
- Introduce storage helpers for reports and custom questions
- Add password-protected admin page to review reports and manage questions
- Enable reporting questions during quizzes and update tests & scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a82560c540832f85eefba652c4efa5